### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Besides the token endpoint the registry uses to request tokens for authenticatio
 
 ### Authentication
 
-Authentication to the Admin API is done via basic authentication using usernam/password. By default it will attempt to use docker credentials stored against the registry on your system, but the user has to have the admin flag set to true. If for some reason credentials cannot be obtained from the docker configuration, you can specify them on the c9ommand line.
+Authentication to the Admin API is done via basic authentication using usernam/password. By default it will attempt to use docker credentials stored against the registry on your system, but the user has to have the admin flag set to true. If for some reason credentials cannot be obtained from the docker configuration, you can specify them on the command line.
 
 ## PKI
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Besides the token endpoint the registry uses to request tokens for authenticatio
 
 ### Authentication
 
-Authentication to the Admin API is done via basic authentication using usernam/password. By default it will attempt to use docker credentials stored against the registry on your system, but the user has to have the admin flag set to true. If for some reason credentials cannot be obtained from the docker configuration, you can specify them on the command line.
+Authentication to the Admin API is done via basic authentication using username/password. By default it will attempt to use docker credentials stored against the registry on your system, but the user has to have the admin flag set to true. If for some reason credentials cannot be obtained from the docker configuration, you can specify them on the command line.
 
 ## PKI
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following environment values should be set:
 - `REGISTRY_AUTH_TOKEN_SERVICE` this is the name of your service
 - `REGISTRY_AUTH_TOKEN_ISSUER` with value `dockit`
 - `REGISTRY_AUTH_TOKEN_REALM` this should be the https URL of where dockit is listening (example: <https://dockit.private.io/v2/token>)
-- `REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` should be a pem that has all valid signing certs, if using dockit init-conatiner use `/dockit/certs.pem`
+- `REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` should be a pem that has all valid signing certs, if using dockit init-container use `/dockit/certs.pem`
 
 ## SQL
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,6 +1,6 @@
 # Database
 
-Dockit uses [GORM](http://gorm.io) for it's database connections and uses [Snowflake](https://github.com/bwmarrin/snowflake) to generate all the primary keys. The primary database that has been developed against and tested is SQLite. However MySQL has been tested as well.
+Dockit uses [GORM](http://gorm.io) for its database connections and uses [Snowflake](https://github.com/bwmarrin/snowflake) to generate all the primary keys. The primary database that has been developed against and tested is SQLite. However MySQL has been tested as well.
 
 Snowflake is an algorithm from Twitter about generating `int64` integers based on time, node id, and sequential bits that allow for thousands of writes per millisecond. For most users of dockit this once matter and because of that, the default setting is to use a random number per instance on start up and log that ID out in the logs for tracking.
 

--- a/docs/guides/cert-manager.md
+++ b/docs/guides/cert-manager.md
@@ -2,7 +2,7 @@
 
 If you are using cert manager and would like to manage PKI for Dockit using it, the good news is you can. Furthermore this works with any backend that the cert-manager support so long as you can mount the certificate and corresponding private key into the Dockit container.
 
-No matter how you request a certificate, the result end's up in an secret that looks like the following.
+No matter how you request a certificate, the result end's up in a secret that looks like the following.
 
 ```yaml
 apiVersion: v1

--- a/docs/guides/cert-manager.md
+++ b/docs/guides/cert-manager.md
@@ -2,7 +2,7 @@
 
 If you are using cert manager and would like to manage PKI for Dockit using it, the good news is you can. Furthermore this works with any backend that the cert-manager support so long as you can mount the certificate and corresponding private key into the Dockit container.
 
-No matter how you request a certificate the result end's up in an secret that looks like the following.
+No matter how you request a certificate, the result end's up in an secret that looks like the following.
 
 ```yaml
 apiVersion: v1

--- a/docs/guides/cert-manager.md
+++ b/docs/guides/cert-manager.md
@@ -45,7 +45,7 @@ spec:
             path: combined.pem
 ```
 
-## Bonus: Reloader by Stakator
+## Bonus: Reloader by Stakater
 
 You can handle automatic updates and restarts of Dockit by leveraging [Reloader](https://github.com/stakater/Reloader)
 

--- a/docs/guides/cert-manager.md
+++ b/docs/guides/cert-manager.md
@@ -2,7 +2,7 @@
 
 If you are using cert manager and would like to manage PKI for Dockit using it, the good news is you can. Furthermore this works with any backend that the cert-manager support so long as you can mount the certificate and corresponding private key into the Dockit container.
 
-No matter how you request a certificate, the result end's up in a secret that looks like the following.
+No matter how you request a certificate, the result ends up in a secret that looks like the following.
 
 ```yaml
 apiVersion: v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Dockit has an Admin API that is used to manage the permissions. Dockit supports 
 
 ### Authentication
 
-Authentication to the Admin API is done via basic authentication using usernam/password. By default it will attempt to use docker credentials stored against the registry on your system, but the user has to have the admin flag set to true. If for some reason credentials cannot be obtained from the docker configuration, you can specify them on the command line.
+Authentication to the Admin API is done via basic authentication using username/password. By default it will attempt to use docker credentials stored against the registry on your system, but the user has to have the admin flag set to true. If for some reason credentials cannot be obtained from the docker configuration, you can specify them on the command line.
 
 ## Registries
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ The following environment values should be set:
 - `REGISTRY_AUTH_TOKEN_SERVICE` this is the name of your service
 - `REGISTRY_AUTH_TOKEN_ISSUER` with value `dockit`
 - `REGISTRY_AUTH_TOKEN_REALM` this should be the https URL of where dockit is listening (example: <https://dockit.private.io/v2/token>)
-- `REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` should be a pem that has all valid signing certs, if using dockit init-conatiner use `/dockit/certs.pem`
+- `REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE` should be a pem that has all valid signing certs, if using dockit init-container use `/dockit/certs.pem`
 
 ## CLI
 

--- a/docs/init-container.md
+++ b/docs/init-container.md
@@ -1,6 +1,6 @@
 # Init Container Support
 
-Dockit comes with an `init-container` subcommand that's designed to be used with Kuberentes init containers. It can even be used with the latest version of docker compose.
+Dockit comes with an `init-container` subcommand that's designed to be used with Kubernetes init containers. It can even be used with the latest version of docker compose.
 
 The `init-container` subcommand is designed to make an http call against the dockit api server to retrieve all non-expired certificates in it's database and write those to a file. The docker distribution registry can then read the file from disk on start and used to validate JWT tokens.
 

--- a/docs/init-container.md
+++ b/docs/init-container.md
@@ -2,7 +2,7 @@
 
 Dockit comes with an `init-container` subcommand that's designed to be used with Kuberentes init containers. It can even be used with the latest version of docker compose.
 
-The `init-container` subcommand is designed to make an http call against the dockit api server to retrieve all non-expired certificaes in it's database and write those to a file. The docker distribution registry can then read the file from disk on start and used to validate JWT tokens.
+The `init-container` subcommand is designed to make an http call against the dockit api server to retrieve all non-expired certificates in it's database and write those to a file. The docker distribution registry can then read the file from disk on start and used to validate JWT tokens.
 
 ## Kubernetes
 

--- a/pkg/apiserver/handlers/token.go
+++ b/pkg/apiserver/handlers/token.go
@@ -186,7 +186,7 @@ func (h *handlers) Token(w http.ResponseWriter, r *http.Request) {
 		signingMethod = fmt.Sprintf("RS%d", pki.Bits)
 	} else {
 		err := fmt.Errorf("invalid pki type: %s", pki.Type)
-		log.WithError(err).Error("unknown signing algorith")
+		log.WithError(err).Error("unknown signing algorithm")
 		response.New(w, r).AddError(err).Send(500)
 		return
 	}

--- a/pkg/commands/rbac/global.go
+++ b/pkg/commands/rbac/global.go
@@ -32,12 +32,12 @@ var (
 		},
 		&cli.StringFlag{
 			Name:    "username",
-			Usage:   "manually specify username, otherwise will attempt to retrieve from docker store",
+			Usage:   "manually specify username; otherwise, will attempt to retrieve from docker store",
 			EnvVars: []string{"DOCKIT_USERNAME", "DOCKIT_GRANT_USERNAME"},
 		},
 		&cli.StringFlag{
 			Name:    "password",
-			Usage:   "manually specify password, otherwise will attempt to retrieve from docker store",
+			Usage:   "manually specify password; otherwise, will attempt to retrieve from docker store",
 			EnvVars: []string{"DOCKIT_PASSWORD", "DOCKIT_GRANT_PASSWORD"},
 		},
 	}

--- a/pkg/commands/rbac/rbac.go
+++ b/pkg/commands/rbac/rbac.go
@@ -25,12 +25,12 @@ func init() {
 		},
 		&cli.StringFlag{
 			Name:    "username",
-			Usage:   "manually specify username, otherwise will attempt to retrieve from docker store",
+			Usage:   "manually specify username; otherwise, will attempt to retrieve from docker store",
 			EnvVars: []string{"DOCKIT_USERNAME", "DOCKIT_GRANT_USERNAME"},
 		},
 		&cli.StringFlag{
 			Name:    "password",
-			Usage:   "manually specify password, otherwise will attempt to retrieve from docker store",
+			Usage:   "manually specify password; otherwise, will attempt to retrieve from docker store",
 			EnvVars: []string{"DOCKIT_PASSWORD", "DOCKIT_GRANT_PASSWORD"},
 		},
 	}

--- a/pkg/commands/rbac/template.go
+++ b/pkg/commands/rbac/template.go
@@ -34,12 +34,12 @@ func preinit() {
 		},
 		&cli.StringFlag{
 			Name:    "username",
-			Usage:   "manually specify username, otherwise will attempt to retrieve from docker store",
+			Usage:   "manually specify username; otherwise, will attempt to retrieve from docker store",
 			EnvVars: []string{"DOCKIT_USERNAME", "DOCKIT_GRANT_USERNAME"},
 		},
 		&cli.StringFlag{
 			Name:    "password",
-			Usage:   "manually specify password, otherwise will attempt to retrieve from docker store",
+			Usage:   "manually specify password; otherwise, will attempt to retrieve from docker store",
 			EnvVars: []string{"DOCKIT_PASSWORD", "DOCKIT_GRANT_PASSWORD"},
 		},
 	}


### PR DESCRIPTION
This isn't a complete set of fixes.... https://github.com/check-spelling-sandbox/dockit/actions/runs/17473234231/attempts/1#summary-49626620554 identifies some other things that are problematic...

https://github.com/ekristen/dockit/blob/bb55a0196b869553253d175269c4fc5000e7a591/docs/index.md#L70

>  The `docker-compose.yml` in the repository is setup to deploy the docker distribution registry version 2 and point it at the `./hack/pki` folder to load the cert bundle. 

I can't figure out what it's trying to say... I know `set up` should be two words; I can't tell what `version 2` means:

https://github.com/ekristen/dockit/blob/bb55a0196b869553253d175269c4fc5000e7a591/docker-compose.yml#L1
https://github.com/ekristen/dockit/blob/bb55a0196b869553253d175269c4fc5000e7a591/docker-compose.yml#L24

I can't tell if the first half is instructing users to make a change (in which case it should be reworded) or if it's a statement of fact (in which case it should be clarified). And I can't figure out what `hack/pki` is as there's no sign of it.